### PR TITLE
chore: add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     name: Build and Release


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a workflow-level environment variable to all GitHub Actions workflow files.

## Why

GitHub is migrating Actions runners from Node.js 20 to Node.js 24. This environment variable opts into the new runtime ahead of the forced migration, allowing us to:

- **Detect compatibility issues early** before the automatic cutover
- **Control the rollout** by opting in on our own schedule
- **Ensure CI/CD reliability** by validating all actions work with Node.js 24

## Changes

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to workflow-level `env:` blocks
- Files that already had the variable were left unchanged

## References

- [GitHub Actions: All actions will run on Node20 instead of Node16 by default](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- [GitHub Actions: Actions Runner support for Node.js 24](https://github.blog/changelog/2025-05-06-github-actions-actions-runner-support-for-node-js-24/)