### PR TITLE
Add .deb package generation for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,27 @@ jobs:
           # Linux
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
+              debArch: i386,
               runner: 'ubuntu-latest' }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
+              debArch: amd64,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
+              debArch: armel,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
+              debArch: armhf,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
+              debArch: arm64,
               runner: 'ubuntu-latest' }
 
           # macOS
@@ -110,3 +115,30 @@ jobs:
         run: |
           cp ./target/${{ matrix.target.rustTarget }}/release/${{ env.APP_NAME }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} ./${{ env.APP_NAME }}-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} &&
           gh release upload ${{ github.event.release.tag_name }} ./${{ env.APP_NAME }}-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}#"${{ env.APP_NAME }}-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} (${{ matrix.target.displayName }})"
+
+      - name: Build .deb package
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        run: |
+          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/hello_world dpkg/usr/local/bin/
+          chmod 755 dpkg/usr/local/bin/hello_world
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cat > dpkg/DEBIAN/control << EOF
+          Package: hello_world
+          Version: $VERSION
+          Architecture: ${{ matrix.target.debArch }}
+          Maintainer: richardsondev
+          Description: Rust application template
+          EOF
+          sed -i 's/^          //' dpkg/DEBIAN/control
+          dpkg-deb --build dpkg hello_world_${VERSION}_${{ matrix.target.debArch }}.deb
+
+      - name: Upload .deb Release Asset
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          gh release upload ${{ github.event.release.tag_name }} ./hello_world_${VERSION}_${{ matrix.target.debArch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,20 +119,20 @@ jobs:
       - name: Build .deb package
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
         run: |
-          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
-          cp ./target/${{ matrix.target.rustTarget }}/release/hello_world dpkg/usr/local/bin/
-          chmod 755 dpkg/usr/local/bin/hello_world
+          mkdir -p dpkg/DEBIAN dpkg/usr/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/${{ env.APP_NAME }} dpkg/usr/bin/
+          chmod 755 dpkg/usr/bin/${{ env.APP_NAME }}
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           cat > dpkg/DEBIAN/control << EOF
-          Package: hello_world
+          Package: ${{ env.APP_NAME }}
           Version: $VERSION
           Architecture: ${{ matrix.target.debArch }}
           Maintainer: richardsondev
           Description: Rust application template
           EOF
           sed -i 's/^          //' dpkg/DEBIAN/control
-          dpkg-deb --build dpkg hello_world_${VERSION}_${{ matrix.target.debArch }}.deb
+          dpkg-deb --build dpkg ${{ env.APP_NAME }}_${VERSION}_${{ matrix.target.debArch }}.deb
 
       - name: Upload .deb Release Asset
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
@@ -141,4 +141,4 @@ jobs:
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          gh release upload ${{ github.event.release.tag_name }} ./hello_world_${VERSION}_${{ matrix.target.debArch }}.deb
+          gh release upload ${{ github.event.release.tag_name }} --clobber ./${{ env.APP_NAME }}_${VERSION}_${{ matrix.target.debArch }}.deb


### PR DESCRIPTION
## Summary

Adds `.deb` package generation to the release workflow for all Linux architectures. As a template repo, this demonstrates how to produce Debian packages from a Rust CI pipeline.

## Changes

- Added `debArch` field to each Linux target in the build matrix (`i386`, `amd64`, `armel`, `armhf`, `arm64`)
- Added a `Build .deb package` step that uses `dpkg-deb` to create Debian packages after the binary is compiled
- Added `Upload .deb Release Asset` step with `--clobber` for idempotent re-runs
- Uses `env.APP_NAME` consistently for binary paths and package naming
- Binary installs to `/usr/bin/hello_world`

## How it works

On a `release` event, each Linux matrix job creates a `.deb` package using `dpkg-deb --build`. The package contains the binary at `/usr/bin/hello_world` and a `DEBIAN/control` file with package name, version (from the release tag), and architecture. The `.deb` is uploaded to the GitHub Release alongside existing raw binaries.

## Architectures

| Debian Arch | Rust Target |
|---|---|
| `amd64` | `x86_64-unknown-linux-gnu` |
| `i386` | `i686-unknown-linux-gnu` |
| `arm64` | `aarch64-unknown-linux-gnu` |
| `armhf` | `armv7-unknown-linux-gnueabihf` |
| `armel` | `arm-unknown-linux-gnueabi` |

## Usage

```bash
sudo dpkg -i hello_world_0.02_amd64.deb
hello_world
```
